### PR TITLE
Refactor/save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can also just draw a scale diagramm with the root and the name of the scale.
 
     from fretboardgtr import ScaleGtr, ScaleFromName
     
-    F=ScaleGtr(ScaleFromName(root='F#',mode='Ionian'))
+    F=ScaleGtr(ScaleFromName(root='F#', mode='Ionian'))
     F.customtuning(['E','A','D','G','B','E'])
     F.pathname('TestScaleName.svg')
     F.theme(show_note_name=True)
@@ -147,10 +147,21 @@ You can also just draw a scale diagramm with the root and the name of the scale.
 <p align="center">
   <img src="https://github.com/antscloud/fretboardgtr/blob/master/img/TestScaleName.svg" width=70%  height=auto />
 </p>
+
+For convenience, modes are also defined as Enum:
+
+    from fretboardgtr import ScaleGtr, ScaleFromName, Mode
+    
+    F=ScaleGtr(ScaleFromName(root='F#', mode=Mode.IONIAN))
+    F.customtuning(['E','A','D','G','B','E'])
+    F.pathname('TestScaleName.svg')
+    F.theme(show_note_name=True)
+    F.draw()
+    F.save()
     
 ## ChordFromName
 
-You can also just draw a scale diagramm with the root and the type of the chord. The following type are availables : M, (b5), 11, 11#5, 11b5, 13, 13#5, 13b5, 5, 6, 6b5, 7, 7#5, 7b5, 7sus2, 7sus4, 9, 9#5, 9b5, 9sus2, 9sus4, aug, aug6, dim, dim(maj11), dim(maj13), dim(maj7), dim(maj9), dim11, dim13, dim6, dim7, dim9, m, m#5, m(maj11), m(maj11)#5, m(maj13), m(maj13)#5, m(maj7), m(maj7)#5, m(maj9), m(maj9)#5, m11, m11#5, m13, m13#5, m6, m6#5, m7, m7#5, m7b5, m9, m9#5, maj11, maj11#5, maj11b5, maj13, maj13#5, maj13b5, maj7, maj7#5, maj7b5, maj9, maj9#5, maj9b5, sus2, sus2(#5), sus2(b5), sus4, sus4(#5), sus4(b5).
+You can also just draw a scale diagram with the root and the type of the chord. The following type are availables : M, (b5), 11, 11#5, 11b5, 13, 13#5, 13b5, 5, 6, 6b5, 7, 7#5, 7b5, 7sus2, 7sus4, 9, 9#5, 9b5, 9sus2, 9sus4, aug, aug6, dim, dim(maj11), dim(maj13), dim(maj7), dim(maj9), dim11, dim13, dim6, dim7, dim9, m, m#5, m(maj11), m(maj11)#5, m(maj13), m(maj13)#5, m(maj7), m(maj7)#5, m(maj9), m(maj9)#5, m11, m11#5, m13, m13#5, m6, m6#5, m7, m7#5, m7b5, m9, m9#5, maj11, maj11#5, maj11b5, maj13, maj13#5, maj13b5, maj7, maj7#5, maj7b5, maj9, maj9#5, maj9b5, sus2, sus2(#5), sus2(b5), sus4, sus4(#5), sus4(b5).
 
     from fretboardgtr import ScaleGtr, ChordFromName
     
@@ -163,6 +174,16 @@ You can also just draw a scale diagramm with the root and the type of the chord.
  <p align="center">
   <img src="https://github.com/antscloud/fretboardgtr/blob/master/img/TestChordName.svg" width=70%  height=auto />
 </p>
+
+For convenience, most common chords are also defined as Enum:
+
+    from fretboardgtr import ScaleGtr, ChordFromName, Chord
+    
+    F=ScaleGtr(ChordFromName(root='C', quality=Chord.MAJOR))
+    F.customtuning(['D','A','D','G','A','D'])
+    F.pathname('TestChordName.svg')
+    F.draw()
+    F.save()
 
 ## Enharmonic
 

--- a/fretboardgtr/__init__.py
+++ b/fretboardgtr/__init__.py
@@ -3,4 +3,4 @@
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
-from fretboardgtr.constants import Mode
+from fretboardgtr.constants import Mode, Chord

--- a/fretboardgtr/__init__.py
+++ b/fretboardgtr/__init__.py
@@ -3,3 +3,4 @@
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
+from fretboardgtr.constants import Mode

--- a/fretboardgtr/constants.py
+++ b/fretboardgtr/constants.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 from enum import Enum
 
+
 class Mode(str, Enum):
     """Makes it easier to list and select a mode, e.g. with auto-completion
-    Mode.MIXOLYDIAN can be used instead of the 'Mixolydian' string.
+    Mode.MIXOLYDIAN can be used instead of the 'Mixolydian' literal string.
     """
     AEOLIAN = 'Aeolian'
     ALTERED = 'Altered'
@@ -22,7 +23,7 @@ class Mode(str, Enum):
     LYDIAN = 'Lydian'
     LYDIAN_B7 = 'Lydianb7'
     LYDIAN_BEC9 = 'Lydianbec9'
-    MAJOR = 'Ionian' # For convenience
+    MAJOR = 'Ionian'  # For convenience
     MAJOR_BEBOP = 'Majorbebop'
     MAJOR_BLUE = 'Majorblue'
     MAJOR_PENTATONIC = 'Majorpentatonic'
@@ -37,6 +38,7 @@ class Mode(str, Enum):
     SUPER_LOCRIAN_BB7 = 'Superlocrianbb7'
     WHOLE_TONE = 'Wholetone'
     WHOLE_TONE_HALF_TONE = 'Wholetonehalftone'
+
 
 SCALES_DICT = {
     'Ionian': [0, 2, 4, 5, 7, 9, 11],
@@ -71,7 +73,38 @@ SCALES_DICT = {
     'Majorbebop': [0, 2, 3, 5, 7, 8, 9, 10]
 }
 
-CHORDS_DICT_ESSENTIAL={'M': [0, 4, 7],
+
+class Chord(str, Enum):
+    """Makes it easier to list and select a chord, e.g. with auto-completion
+    Chord.MAJOR can be used instead of the 'M' literal string.
+
+    Not every defined Chord from CHORDS_DICT_ESSENTIAL is defined as an enum
+    here, only the most common ones.
+    """
+    MAJOR = 'M'
+    ELEVENTH = '11'
+    THIRTEENTH = '13'
+    FIFTH = '5'
+    POWER = '5'  # For convenience
+    SIXTH = '6'
+    SEVENTH = '7'
+    DOMINANT_SEVENTH = '7'  # For convenience
+    NINTH = '9'
+    AUGMENTED = 'aug'
+    DIMINISHED = 'dim'
+    DIMINISHED_SEVENTH = 'dim7'
+    MINOR = 'm'
+    MINOR_ELEVENTH = 'm11'
+    MINOR_THIRTEENTH = 'm13'
+    MINOR_SIXTH = 'm6'
+    MINOR_SEVENTH = 'm7'
+    MINOR_NINTH = 'm9'
+    MAJOR_SEVENTH = 'maj7'
+    SUSPENDED_FOURTH = 'sus4'
+    SUSPENDED_SECOND = 'sus2'
+
+
+CHORDS_DICT_ESSENTIAL = {'M': [0, 4, 7],
  '(b5)': [0, 4, 6],
  '11': [0, 4, 5, 7, 10],
  '11#5': [0, 4, 5, 8, 10],

--- a/fretboardgtr/constants.py
+++ b/fretboardgtr/constants.py
@@ -1,4 +1,43 @@
 from __future__ import absolute_import
+from enum import Enum
+
+class Mode(str, Enum):
+    """Makes it easier to list and select a mode, e.g. with auto-completion
+    Mode.MIXOLYDIAN can be used instead of the 'Mixolydian' string.
+    """
+    AEOLIAN = 'Aeolian'
+    ALTERED = 'Altered'
+    AUGMENTED_LYDIAN = 'Augmentedlydian'
+    DOMINANT_BEBOP = 'Dominantbebop'
+    DORIAN = 'Dorian'
+    DORIAN_B9 = 'Dorianb9'
+    DORIAN_SHARP11 = 'Doriansharp11'
+    HALF_TONE_WHOLE_TONE = 'Halftonewholetone'
+    HARMONIC_MINOR = 'Harmonicminor'
+    IONIAN = 'Ionian'
+    IONIAN_SHARP5 = 'Ioniansharp5'
+    LOCRIAN = 'Locrian'
+    LOCRIAN_BEC13 = 'Locrianbec13'
+    LOCRIAN_BEC9 = 'Locrianbec9'
+    LYDIAN = 'Lydian'
+    LYDIAN_B7 = 'Lydianb7'
+    LYDIAN_BEC9 = 'Lydianbec9'
+    MAJOR = 'Ionian' # For convenience
+    MAJOR_BEBOP = 'Majorbebop'
+    MAJOR_BLUE = 'Majorblue'
+    MAJOR_PENTATONIC = 'Majorpentatonic'
+    MELOD_ICMINOR = 'Melodicminor'
+    MINOR_BLUES = 'Minorblues'
+    MINOR_PENTATONIC = 'Minorpentatonic'
+    MIXOLYDIAN = 'Mixolydian'
+    MIXOLYDIAN_B13 = 'Mixolydianb13'
+    MIXOLYDIAN_B9_B13 = 'Mixolydianb9b13'
+    NATURAL_MINOR = 'Aeolian'
+    PHRYGIAN = 'Phrygian'
+    SUPER_LOCRIAN_BB7 = 'Superlocrianbb7'
+    WHOLE_TONE = 'Wholetone'
+    WHOLE_TONE_HALF_TONE = 'Wholetonehalftone'
+
 SCALES_DICT = {
     'Ionian': [0, 2, 4, 5, 7, 9, 11],
     'Dorian': [0, 2, 3, 5, 7, 9, 10],

--- a/fretboardgtr/fretboardgtr.py
+++ b/fretboardgtr/fretboardgtr.py
@@ -457,7 +457,7 @@ class FretBoardGtr():
             extension = self.path.suffix
 
         if not extension.strip():
-            raise ValueError("Please specify an extension, either in self.path or as argument.")
+            raise ValueError("Please specify an extension, either in self.path or as argument for save.")
 
         if extension[0] != '.':
             extension = '.' + extension  # For Pathlib

--- a/fretboardgtr/fretboardgtr.py
+++ b/fretboardgtr/fretboardgtr.py
@@ -435,6 +435,15 @@ class FretBoardGtr():
         If another extension is specified (e.g. '.png'), or if path is set to 'file.png',
         the drawing will be saved as the corresponding format.
 
+        Supported extensions are :
+        * svg
+        * png
+        * pdf
+        * gif
+        * jpg
+        * bmp
+        * ppm
+
         >>> F.pathname('test.pdf'); F.save()
         >>> F.pathname('test'); F.save('.pdf')
         >>> F.pathname('test'); F.save('.pdf'); F.save('.png')

--- a/fretboardgtr/scalegtr.py
+++ b/fretboardgtr/scalegtr.py
@@ -5,8 +5,15 @@ import svgwrite
 
 class ScaleFromName:
     """
-    Object that generate a results dictionnary containing the root and the scale as argument from root and mode strings.
+    Object that generate a results dictionary containing the root and
+    the scale as argument from root and mode strings.
+
     >>> ScaleFromName(root='C',mode='Dorian').results
+        {'root': 'C', 'scale': ['C', 'D', 'D#', 'F', 'G', 'A', 'A#']}
+
+    Mode enum can also be used:
+
+    >>> ScaleFromName(root='C',mode=Mode.DORIAN).results
         {'root': 'C', 'scale': ['C', 'D', 'D#', 'F', 'G', 'A', 'A#']}
     """
     

--- a/tests/test_fretboardgtr.py
+++ b/tests/test_fretboardgtr.py
@@ -78,7 +78,7 @@ class FretBoardGtrTest(unittest.TestCase):
     def test_pathname(self):
         F=FretBoardGtr()
         F.pathname("/chords/chordsimage")
-        self.assertEqual(F.path,"/chords/chordsimage")
+        self.assertEqual(str(F.path),"/chords/chordsimage")
 
     def test_customtuning(self):
         F=FretBoardGtr()

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -5,7 +5,7 @@ import unittest
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
-from fretboardgtr.constants import Mode
+from fretboardgtr.constants import Mode, Chord
 
 path="tests/images/integrate/"
 class IntegrateTest(unittest.TestCase):
@@ -89,7 +89,7 @@ class IntegrateTest(unittest.TestCase):
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
     def test_TestChordName(self):
-        F=ScaleGtr(ChordFromName(root='C',quality='M'))
+        F=ScaleGtr(ChordFromName(root='C',quality=Chord.MAJOR))
         F.customtuning(['D','A','D','G','A','D'])
         F.pathname('img/TestChordName.svg')
         F.draw()

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -5,7 +5,9 @@ from fretboardgtr.constants import Mode, Chord
 import tempfile
 from pathlib import Path
 
-path = "tests/images/integrate/"
+path = Path("tests/images/integrate/")
+
+
 class IntegrateTest(unittest.TestCase):
 
     def test_scale_degree_name(self):
@@ -14,7 +16,7 @@ class IntegrateTest(unittest.TestCase):
         F.pathname('img/scale_degree_name.svg')
         F.draw()
 
-        with open(path+'scale_degree_name.svg','r') as f:
+        with open(path / 'scale_degree_name.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -25,7 +27,7 @@ class IntegrateTest(unittest.TestCase):
         F.pathname('img/scale_no_color.svg')
         F.draw()
 
-        with open(path+'scale_no_color.svg','r') as f:
+        with open(path / 'scale_no_color.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -37,7 +39,7 @@ class IntegrateTest(unittest.TestCase):
         F.pathname('img/scale_note_name.svg')
         F.draw()
 
-        with open(path+'scale_note_name.svg','r') as f:
+        with open(path / 'scale_note_name.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -48,7 +50,7 @@ class IntegrateTest(unittest.TestCase):
         F.theme(show_note_name=True)
         F.draw()
 
-        with open(path+'TestScaleName.svg','r') as f:
+        with open(path / 'TestScaleName.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -59,7 +61,7 @@ class IntegrateTest(unittest.TestCase):
         F.theme(show_note_name=True)
         F.draw()
 
-        with open(path+'TestScaleNameEnhar.svg','r') as f:
+        with open(path / 'TestScaleNameEnhar.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -69,9 +71,9 @@ class IntegrateTest(unittest.TestCase):
         F.theme(last_fret=24)
         F.pathname('img/TestScaleNameEnhar24.svg')
         F.theme(show_note_name=True)
-        F.draw()    
+        F.draw()
 
-        with open(path+'TestScaleNameEnhar24.svg','r') as f:
+        with open(path / 'TestScaleNameEnhar24.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -82,7 +84,7 @@ class IntegrateTest(unittest.TestCase):
         F.set_color(perfectfourth='rgb(0, 0, 0)',root='rgb(0, 0, 0)')
         F.draw()
 
-        with open(path+'chord_degree_name.svg','r') as f:
+        with open(path / 'chord_degree_name.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -92,7 +94,7 @@ class IntegrateTest(unittest.TestCase):
         F.pathname('img/TestChordName.svg')
         F.draw()
 
-        with open(path+'TestChordName.svg','r') as f:
+        with open(path / 'TestChordName.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -102,7 +104,7 @@ class IntegrateTest(unittest.TestCase):
         F.pathname('img/lefthandchord.svg')
         F.draw()
 
-        with open(path+'lefthandchord.svg','r') as f:
+        with open(path / 'lefthandchord.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -113,7 +115,7 @@ class IntegrateTest(unittest.TestCase):
         F.theme(show_note_name=True)
         F.draw()
 
-        with open(path+'chord_name_long.svg','r') as f:
+        with open(path / 'chord_name_long.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
@@ -124,7 +126,7 @@ class IntegrateTest(unittest.TestCase):
         F.theme(show_note_name=True,background_color='rgb(70,70,70)')
         F.draw()
 
-        with open(path+'chord_name_background.svg','r') as f:
+        with open(path / 'chord_name_background.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -2,8 +2,10 @@ import unittest
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
 from fretboardgtr.constants import Mode, Chord
+import tempfile
+from pathlib import Path
 
-path="tests/images/integrate/"
+path = "tests/images/integrate/"
 class IntegrateTest(unittest.TestCase):
 
     def test_scale_degree_name(self):
@@ -125,6 +127,19 @@ class IntegrateTest(unittest.TestCase):
         with open(path+'chord_name_background.svg','r') as f:
             file=f.read()
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
+
+
+    def test_save_diagram_in_different_formats(self):
+        extensions = ['png', 'pdf', 'svg', 'bmp', 'gif']
+        F=ScaleGtr(ScaleFromName(root='A',mode=Mode.MINOR_PENTATONIC))
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            for extension in extensions:
+                with self.subTest(ext=extension):
+                    out = Path(tmpdirname) / f'temp.{extension}'
+                    F.pathname(out)
+                    self.assertFalse(out.exists(), f"{out} should not have been created yet")
+                    F.save(extension=extension)
+                    self.assertTrue(out.exists(), f"{out} should have been written.")
 
 
 if __name__ == "__main__" :

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -133,15 +133,17 @@ class IntegrateTest(unittest.TestCase):
 
     def test_save_diagram_in_different_formats(self):
         extensions = ['png', 'pdf', 'bmp', 'gif', 'svg'] # NOTE: SVG should be the last one
-        F=ScaleGtr(ScaleFromName(root='A',mode=Mode.MINOR_PENTATONIC))
+        F=ScaleGtr(root='A')
         with tempfile.TemporaryDirectory() as tmpdirname:
             for ext in extensions:
                 with self.subTest(ext=ext):
                     out = Path(tmpdirname) / f'some_file.{ext}'
                     F.pathname(out)
-                    self.assertFalse(out.exists(), f"{out} should not have been created yet")
+                    self.assertFalse(out.exists(),
+                                     f"{out} should not have been created yet")
                     F.save() # NOTE: Extension has been specified in pathname
-                    self.assertTrue(out.exists(), f"{out} should have been written.")
+                    self.assertTrue(out.exists(),
+                                    f"{out} should have been written.")
                     if ext != 'svg':
                         self.assertFalse(out.with_suffix('.svg').exists(),
                                          f"SVG version should not have been saved next to {out}")
@@ -149,10 +151,13 @@ class IntegrateTest(unittest.TestCase):
                     out2 = Path(tmpdirname) / 'another_file'
                     F.pathname(out2)  # NOTE: Without extension
                     out2 = out2.with_suffix('.' + ext)
-                    self.assertFalse(out2.exists(), f"{out2} should not have been created yet")
+                    self.assertFalse(out2.exists(),
+                                     f"{out2} should not have been created yet")
                     F.save(extension=ext)
-                    self.assertTrue(out2.exists(), f"{out2} should have been written.")
-                    self.assertTrue(out2.stat().st_size > 4_000, f"{out2} should not be empty.")
+                    self.assertTrue(out2.exists(),
+                                    f"{out2} should have been written.")
+                    self.assertTrue(out2.stat().st_size > 1_000,
+                                    f"{out2} should not be empty.")
 
 
 if __name__ == "__main__" :

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,8 +1,4 @@
-import os
-import io
-import sys
 import unittest
-from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
 from fretboardgtr.constants import Mode, Chord

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,10 +1,11 @@
-import os 
+import os
 import io
 import sys
 import unittest
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
+from fretboardgtr.constants import Mode
 
 path="tests/images/integrate/"
 class IntegrateTest(unittest.TestCase):
@@ -43,7 +44,7 @@ class IntegrateTest(unittest.TestCase):
             self.assertEqual(F.dwg.tostring(),file.split('<?xml version="1.0" encoding="utf-8" ?>\n')[1])
 
     def test_TestScaleName(self):
-        F=ScaleGtr(ScaleFromName(root='F#',mode='Ionian'))
+        F=ScaleGtr(ScaleFromName(root='F#',mode=Mode.IONIAN))
         F.customtuning(['E','A','D','G','B','E'])
         F.pathname('img/TestScaleName.svg')
         F.theme(show_note_name=True)

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -130,16 +130,27 @@ class IntegrateTest(unittest.TestCase):
 
 
     def test_save_diagram_in_different_formats(self):
-        extensions = ['png', 'pdf', 'svg', 'bmp', 'gif']
+        extensions = ['png', 'pdf', 'bmp', 'gif', 'svg'] # NOTE: SVG should be the last one
         F=ScaleGtr(ScaleFromName(root='A',mode=Mode.MINOR_PENTATONIC))
         with tempfile.TemporaryDirectory() as tmpdirname:
-            for extension in extensions:
-                with self.subTest(ext=extension):
-                    out = Path(tmpdirname) / f'temp.{extension}'
+            for ext in extensions:
+                with self.subTest(ext=ext):
+                    out = Path(tmpdirname) / f'some_file.{ext}'
                     F.pathname(out)
                     self.assertFalse(out.exists(), f"{out} should not have been created yet")
-                    F.save(extension=extension)
+                    F.save() # NOTE: Extension has been specified in pathname
                     self.assertTrue(out.exists(), f"{out} should have been written.")
+                    if ext != 'svg':
+                        self.assertFalse(out.with_suffix('.svg').exists(),
+                                         f"SVG version should not have been saved next to {out}")
+
+                    out2 = Path(tmpdirname) / 'another_file'
+                    F.pathname(out2)  # NOTE: Without extension
+                    out2 = out2.with_suffix('.' + ext)
+                    self.assertFalse(out2.exists(), f"{out2} should not have been created yet")
+                    F.save(extension=ext)
+                    self.assertTrue(out2.exists(), f"{out2} should have been written.")
+                    self.assertTrue(out2.stat().st_size > 4_000, f"{out2} should not be empty.")
 
 
 if __name__ == "__main__" :

--- a/tests/test_scalegtr.py
+++ b/tests/test_scalegtr.py
@@ -1,10 +1,11 @@
-import os 
+import os
 import io
 import sys
 import unittest
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
+from fretboardgtr.constants import Mode
 
 path="tests/images/scalegtr/"
 class ScaleGtrTest(unittest.TestCase):
@@ -14,7 +15,9 @@ class ScaleGtrTest(unittest.TestCase):
     def test_scalefromname_findscale(self):
         self.assertEqual(ScaleFromName().results,{'root': 'C', 'scale': ['C', 'D', 'E', 'F', 'G', 'A', 'B']})
         self.assertEqual(ScaleFromName(root='D#',mode='Aeolian').results,{'root': 'D#', 'scale': ['D#', 'F', 'F#', 'G#', 'A#', 'B', 'C#']})
+        self.assertEqual(ScaleFromName(root='D#',mode=Mode.AEOLIAN).results,{'root': 'D#', 'scale': ['D#', 'F', 'F#', 'G#', 'A#', 'B', 'C#']})
         self.assertEqual(ScaleFromName(root='A#',mode='Dominantbebop').results,{'root': 'A#', 'scale': ['A#', 'C', 'D', 'D#', 'F', 'G', 'G#', 'A']})
+        self.assertEqual(ScaleFromName(root='A#',mode=Mode.DOMINANT_BEBOP).results,{'root': 'A#', 'scale': ['A#', 'C', 'D', 'D#', 'F', 'G', 'G#', 'A']})
 
 
     def test_chordfromname_findscale(self):

--- a/tests/test_scalegtr.py
+++ b/tests/test_scalegtr.py
@@ -5,7 +5,7 @@ import unittest
 from fretboardgtr.fretboardgtr import FretBoardGtr
 from fretboardgtr.scalegtr import ScaleGtr, ChordFromName, ScaleFromName
 from fretboardgtr.chordgtr import ChordGtr
-from fretboardgtr.constants import Mode
+from fretboardgtr.constants import Mode, Chord
 
 path="tests/images/scalegtr/"
 class ScaleGtrTest(unittest.TestCase):
@@ -23,6 +23,13 @@ class ScaleGtrTest(unittest.TestCase):
     def test_chordfromname_findscale(self):
         self.assertEqual(ChordFromName().results,{'root': 'C', 'scale': ['C', 'E', 'G']})
         self.assertEqual(ChordFromName(root='D#',quality='M').results,{'root': 'D#', 'scale': ['D#', 'G', 'A#']})
+        self.assertEqual(ChordFromName(root='D#',quality=Chord.MAJOR).results,{'root': 'D#', 'scale': ['D#', 'G', 'A#']})
+        self.assertEqual(ChordFromName(root='D',quality=Chord.MINOR).results,{'root': 'D', 'scale': ['D', 'F', 'A']})
+        self.assertEqual(ChordFromName(root='C',quality=Chord.DOMINANT_SEVENTH).results,{'root': 'C', 'scale': ['C', 'E', 'G', 'A#']})
+        self.assertEqual(ChordFromName(root='C',quality=Chord.MAJOR_SEVENTH).results,{'root': 'C', 'scale': ['C', 'E', 'G', 'B']})
+        self.assertEqual(ChordFromName(root='C',quality=Chord.AUGMENTED).results,{'root': 'C', 'scale': ['C', 'E', 'G#']})
+        self.assertEqual(ChordFromName(root='C',quality=Chord.POWER).results,{'root': 'C', 'scale': ['C', 'G']})
+        self.assertEqual(ChordFromName(root='C',quality=Chord.SUSPENDED_FOURTH).results,{'root': 'C', 'scale': ['C', 'F', 'G']})
         self.assertEqual(ChordFromName(root='E',quality='dim(maj11)').results,{'root': 'E', 'scale': ['E', 'G', 'A', 'A#', 'D#']})
 
 

--- a/tests/test_scalegtr.py
+++ b/tests/test_scalegtr.py
@@ -12,6 +12,13 @@ class ScaleGtrTest(unittest.TestCase):
 
     """" Test case for fretboardgtr"""
 
+    def test_every_mode_is_defined(self):
+        self.assertTrue(len(Mode) >= 7, "At least seven modes should be defined as enum")
+        for mode in Mode:
+            scale = ScaleFromName(root='E', mode=mode)
+            notes = scale.results['scale']
+            self.assertEqual('E', notes[0])
+
     def test_scalefromname_findscale(self):
         self.assertEqual(ScaleFromName().results,{'root': 'C', 'scale': ['C', 'D', 'E', 'F', 'G', 'A', 'B']})
         self.assertEqual(ScaleFromName(root='D#',mode='Aeolian').results,{'root': 'D#', 'scale': ['D#', 'F', 'F#', 'G#', 'A#', 'B', 'C#']})
@@ -19,6 +26,12 @@ class ScaleGtrTest(unittest.TestCase):
         self.assertEqual(ScaleFromName(root='A#',mode='Dominantbebop').results,{'root': 'A#', 'scale': ['A#', 'C', 'D', 'D#', 'F', 'G', 'G#', 'A']})
         self.assertEqual(ScaleFromName(root='A#',mode=Mode.DOMINANT_BEBOP).results,{'root': 'A#', 'scale': ['A#', 'C', 'D', 'D#', 'F', 'G', 'G#', 'A']})
 
+    def test_every_chord_enum_is_defined(self):
+        self.assertTrue(len(Chord) >= 12, "Some chords should be defined as enum")
+        for chord_name in Chord:
+            chord = ChordFromName(root='F#', quality=chord_name)
+            notes = chord.results['scale']
+            self.assertEqual('F#', notes[0])
 
     def test_chordfromname_findscale(self):
         self.assertEqual(ChordFromName().results,{'root': 'C', 'scale': ['C', 'E', 'G']})


### PR DESCRIPTION
Refactor of `FretboardGtr#save()`.

it's now possible to call:
* `F.pathname('test.pdf'); F.save()`
* `F.pathname('test'); F.save('.pdf')`
* `F.pathname('test'); F.save('.pdf'); F.save('.png')`

without having to specify an SVG path first.

Existing code should still work as is.